### PR TITLE
Update compilers

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler_version:        # [linux]
+  - 11.2.0                 # [linux]
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]
+fortran_compiler_version:  # [linux or osx]
+  - 11.2.0                 # [linux or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0005-change-setenv-on-windows.patch                     # [win]
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -113,9 +113,11 @@ outputs:
       summary: The postgres runtime libraries and utilities (not the server itself)
 
 about:
-  home: http://www.postgresql.org/
+  home: https://postgresql.org
   license: PostgreSQL
   license_file: COPYRIGHT
+  doc_url: https://www.postgresql.org/docs/
+  dev_url: https://git.postgresql.org/gitweb/?p=postgresql.git;a=summary
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ outputs:
       build:
         # solely for sake of lining up vc versions and other runtimes
         - {{ compiler('c') }}
-        - perl                 # [win]
+        - perl             # [win]
         - make             # [unix]
       host:
         # these are here for sake of run_exports taking effect
@@ -75,11 +75,15 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage('libpq') }}
+      ignore_run_exports:
+        - krb5                        # [win]
+        - openssl                     # [win]
       missing_dso_whitelist:          # [win]
         - "*/postgres.exe"            # [win]
         - "*/libssl-1_1*.dll"         # [win]
         - "*/libcrypto-1_1*.dll"      # [win]
         - "$RPATH/gssapi32.dll"       # [win]
+        - "$RPATH/gssapi64.dll"       # [win]
         - "$RPATH/zlib.dll"           # [win]
         - "$RPATH/LIBPGTYPES.dll"     # [win]
         - "$RPATH/LIBECPG.dll"        # [win]
@@ -88,15 +92,15 @@ outputs:
       build:
         # solely for sake of lining up vc versions and other runtimes
         - {{ compiler('c') }}
-        - perl                 # [win]
-        - make             # [unix]
+        - perl                   # [win]
+        - make                   # [unix]
       host:
         # these are here for sake of run_exports taking effect
         - krb5
         - openssl
-        - readline         # [not win]
+        - readline               # [not win]
         - zlib
-        - msinttypes       # [win and vc<14]
+        - msinttypes             # [win and vc<14]
     script: install_runtime.sh   # [unix]
     script: install_runtime.bat  # [win]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,6 +120,7 @@ outputs:
 about:
   home: https://postgresql.org
   license: PostgreSQL
+  license_family: Other
   license_file: COPYRIGHT
   doc_url: https://www.postgresql.org/docs/
   dev_url: https://git.postgresql.org/gitweb/?p=postgresql.git;a=summary

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,7 @@ outputs:
         - "*/postgres.exe"            # [win]
         - "*/libssl-1_1*.dll"         # [win]
         - "*/libcrypto-1_1*.dll"      # [win]
+        - "$RPATH/gssapi32.dll"       # [win]
         - "$RPATH/zlib.dll"           # [win]
         - "$RPATH/LIBPGTYPES.dll"     # [win]
         - "$RPATH/LIBECPG.dll"        # [win]


### PR DESCRIPTION
Actions:
1. Update compilers in `cbc.yaml`
2. Bump build number to `3`
3. Add `krb5` and `openssl` in `ignore_run_exports` on `win`
4. Add in missing_dso_whitelist:
```
        - "$RPATH/gssapi32.dll"       # [win]
        - "$RPATH/gssapi64.dll"       # [win]
```
6. Fix home url with HTTPS 
7. Add doc and dev urls