### PR TITLE
Update to 12.17

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "12.15" %}
-{% set sha256 = "bb5206e2864c1c4579938b96ea6096d155f22abf2d2cc2aa57571e3c4cb12b36" %}
+{% set version = "12.17" %}
+{% set sha256 = "93e8e1b23981d5f03c6c5763f77b28184c1ce4db7194fa466e2edb65d9c1c5f6" %}
 {% set libpqver = '.'.join(("5", version.split('.')[0])) %}
 
 package:
@@ -17,7 +17,7 @@ source:
     - 0005-change-setenv-on-windows.patch                     # [win]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
postgresql+psql 12.17

**Destination channel:** defaults

### Links

- [PKG-3364](https://anaconda.atlassian.net/browse/PKG-3364)
- [Upstream repository](https://github.com/postgres/postgres/tree/REL_12_17) (mirror)

### Explanation of changes:

Update to 12.17 to fix CVE-2023-39417.


[PKG-3364]: https://anaconda.atlassian.net/browse/PKG-3364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ