### PR TITLE
Updated to 17.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "17.0" %}
-{% set sha256 = "7e276131c0fdd6b62588dbad9b3bb24b8c3498d5009328dba59af16e819109de" %}
+{% set version = "17.2" %}
+{% set sha256 = "82ef27c0af3751695d7f64e2d963583005fbb6a0c3df63d0e4b42211d7021164" %}
 {% set libpqver = '.'.join(("5", version.split('.')[0])) %}
 
 package:


### PR DESCRIPTION
postgresql 17.2

**Destination channel:** defaults

### Links

- [PKG-6244](https://anaconda.atlassian.net/browse/PKG-6244)
- [Upstream repository](https://github.com/postgres/postgres/tree/6304632eaa2107bb1763d29e213ff166ff6104c0)
- [Upstream changelog/diff](https://www.postgresql.org/docs/release/17.2/)

### Explanation of changes:

- Addresses CVE-2024-10979


[PKG-6244]: https://anaconda.atlassian.net/browse/PKG-6244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ