### PR TITLE
Update to v17.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "17.2" %}
-{% set sha256 = "82ef27c0af3751695d7f64e2d963583005fbb6a0c3df63d0e4b42211d7021164" %}
+{% set version = "17.4" %}
+{% set sha256 = "c4605b73fea11963406699f949b966e5d173a7ee0ccaef8938dec0ca8a995fe7" %}
 {% set libpqver = '.'.join(("5", version.split('.')[0])) %}
 
 package:


### PR DESCRIPTION
postgresql 17.4

**Destination channel:** defaults

### Links

- [PKG-7123](https://anaconda.atlassian.net/browse/PKG-7123)
- [Upstream repository](https://github.com/postgres/postgres/tree/REL_17_4)
- [Upstream changelog/diff](https://www.postgresql.org/docs/release/17.4/)

### Explanation of changes:

- Addresses CVE-2025-10947

[PKG-7123]: https://anaconda.atlassian.net/browse/PKG-7123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ