### PR TITLE
PKG-11952-rebuild-postgresql-17.6-for-libkrb5-1.22.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,12 +9,6 @@ export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
-if [ "${build_platform}" == "linux-s390x" ]; then
-  EXTRA_OPTS=""
-else
-  EXTRA_OPTS="--with-ldap"
-fi
-
 ./configure \
       --prefix=$PREFIX \
       --with-readline \
@@ -29,15 +23,10 @@ fi
       --with-zstd \
       --with-uuid=e2fs \
       --with-system-tzdata=$PREFIX/share/zoneinfo \
-      $EXTRA_OPTS \
+      --with-ldap \
       PG_SYSROOT="undefined"
 
 make -j $CPU_COUNT
 make -j $CPU_COUNT -C contrib
-
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]] && [ ${target_platform} == linux-64 ]; then
-    # osx, aarch64, and ppc64le checks fail in some strange ways
-    make check || exit 0
-    make check -C contrib
-    # make check -C src/interfaces/ecpg
-fi
+make check || exit 0
+make check -C contrib

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,11 @@ export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
+# ARMv8+ CRC32 vector support
+if [[ "${target_platform}" == "linux-aarch64" ]]; then
+    export CPPFLAGS="${CPPFLAGS:-} -DHWCAP_CRC32=0x80 -DHWCAP_SVE=0x400000"
+fi
+
 ./configure \
       --prefix=$PREFIX \
       --with-readline \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -33,5 +33,9 @@ fi
 
 make -j $CPU_COUNT
 make -j $CPU_COUNT -C contrib
-make check || exit 0
-make check -C contrib
+
+if [ ${target_platform} == linux-* ]; then
+    # osx fail due to paths mismatch during build and test stages
+    make check
+    make check -C contrib
+fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-c_compiler_version:        # [linux]
-  - 11.2.0                 # [linux]
-cxx_compiler_version:      # [linux]
-  - 11.2.0                 # [linux]
-fortran_compiler_version:  # [linux or osx]
-  - 11.2.0                 # [linux or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,7 +128,7 @@ outputs:
       run:
         # Versions constraints come from run_exports
         - libkrb5
-        - openldap    # [not (win or s390x)]
+        - openldap    # [not win]
         - openssl
         - zlib        # [win]
         - msinttypes  # [win and vc<14]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -27,10 +27,8 @@ requirements:
     - msys2-bison      # [win]
     - msys2-diffutils  # [win]
     - msys2-flex       # [win]
-    - msys2-patch      # [win]
     - make             # [unix]
     - meson            # [win]
-    - patch            # [unix]
     - perl
     - pkg-config       # [unix]
     - msys2-posix      # [win]


### PR DESCRIPTION
[PKG-11952](https://anaconda.atlassian.net/browse/PKG-11952) 
Rebuild for libkrb5 1.22.1

[PKG-11952]: https://anaconda.atlassian.net/browse/PKG-11952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ