### PR TITLE
Update version to 17.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - msys2-flex       # [win]
     - make             # [unix]
     - meson            # [win]
-    - perl {{ perl }}
+    - perl
     - pkg-config       # [unix]
     - msys2-posix      # [win]
   host:
@@ -61,7 +61,7 @@ outputs:
         - {{ compiler('c') }}
         - make             # [unix]
         - meson            # [win]
-        - perl  {{ perl }}
+        - perl
       host:
         # these are here for sake of run_exports taking effect
         - libkrb5 {{ krb5 }}
@@ -117,7 +117,7 @@ outputs:
         - {{ compiler('c') }}
         - make   # [unix]
         - meson  # [win]
-        - perl  {{ perl }}
+        - perl
       host:
         # these are here for sake of run_exports taking effect
         - libkrb5 {{ krb5 }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "17.6" %}
+{% set version = "17.9" %}
 {% set libpqver = '.'.join(("5", version.split('.')[0])) %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://ftp.postgresql.org/pub/source/v{{ version }}/postgresql-{{ version }}.tar.bz2
-  sha256: e0630a3600aea27511715563259ec2111cd5f4353a4b040e0be827f94cd7a8b0
+  sha256: 3b9a62538a8da151e807a3ddb1198e8605f2032544d78f403ae883d27ecf1ee4
   patches:
     - patches/fix_gssapi_setenv_win.patch       # [win]
     - patches/fix_auth_setenv_win.patch         # [win]
@@ -16,7 +16,7 @@ source:
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - msys2-flex       # [win]
     - make             # [unix]
     - meson            # [win]
-    - perl
+    - perl {{ perl }}
     - pkg-config       # [unix]
     - msys2-posix      # [win]
   host:
@@ -61,7 +61,7 @@ outputs:
         - {{ compiler('c') }}
         - make             # [unix]
         - meson            # [win]
-        - perl
+        - perl  {{ perl }}
       host:
         # these are here for sake of run_exports taking effect
         - libkrb5 {{ krb5 }}
@@ -117,7 +117,7 @@ outputs:
         - {{ compiler('c') }}
         - make   # [unix]
         - meson  # [win]
-        - perl
+        - perl  {{ perl }}
       host:
         # these are here for sake of run_exports taking effect
         - libkrb5 {{ krb5 }}


### PR DESCRIPTION
postgresql 17.9

**Destination channel:** defaults

### Links

- [PKG-13515](https://anaconda.atlassian.net/browse/PKG-13515) 
- [Upstream repository](https://git.postgresql.org/gitweb/?p=postgresql.git;a=summary)

### Explanation of changes:
- New version number and new build number


[PKG-13515]: https://anaconda.atlassian.net/browse/PKG-13515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ