### PR TITLE
postgresql 18.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "17.9" %}
+{% set version = "17.10" %}
 {% set libpqver = '.'.join(("5", version.split('.')[0])) %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://ftp.postgresql.org/pub/source/v{{ version }}/postgresql-{{ version }}.tar.bz2
-  sha256: 3b9a62538a8da151e807a3ddb1198e8605f2032544d78f403ae883d27ecf1ee4
+  sha256: 078a03516dcdbdb705fecaf415ea3d13a956c589e46f09fed68a06fb00598c90
   patches:
     - patches/fix_gssapi_setenv_win.patch       # [win]
     - patches/fix_auth_setenv_win.patch         # [win]
@@ -16,7 +16,7 @@ source:
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
## Links

- Jira: https://anaconda.atlassian.net/browse/PKG-15996
- Homepage: https://www.postgresql.org
- conda-forge recipe: https://github.com/conda-forge/postgresql-feedstock
- Source: https://git.postgresql.org/gitweb/?p=postgresql.git;a=summary

## Changes

- Bump `postgresql` from `17.9` to `18.4` (major version bump)
- Reset build number to 0
- Replace `libtool` with `gnuconfig` in build requirements; update `build.sh` accordingly
- Extend `libuuid` and `tzdata` from `# [linux]` to `# [not win]`
- `libxslt` restricted to `# [not win]` — no run_exports on Windows, linking it into postgres.exe would cause STATUS_DLL_NOT_FOUND (0xC0000135) at runtime; no XSLT support on Windows was present in PG17 either
- Drop `msinttypes r26` — PG18 dropped MSVC < 14 support; the C99 header shim (`<stdint.h>`, `<inttypes.h>`) is no longer needed
- Remove `fix_mac10_9_clock_realtime.patch` — macOS 10.9 no longer supported by PG18
- Remove `meson test --suite setup` from `bld.bat` — PG18's meson setup suite installs binaries into a `tmp_install` directory mirroring the full conda prefix path, but runtime DLLs (openssl, icu, krb5, etc.) are never copied there; `postgres.exe` crashes with `0xC0000135` (STATUS_DLL_NOT_FOUND); testing belongs in the `test:` phase where the package is fully installed with all its dependencies

## Notes

- Driven by HIGH CVEs: https://lists.debian.org/debian-lts-announce/2026/06/msg00035.html
- `liburing` (io_uring) and `tzcode` skipped — not in main channel
- Windows build keeps `msys2-*` packages (main channel equivalent of conda-forge's `m2-*`)