### PR TITLE
PKG-16106: fix lz4 DLL name mismatch on Windows via pkg-config patch

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -33,6 +33,14 @@ if "%ARCH%" == "32" (
    set ARCH=x64
 )
 
+:: lz4-c ships lz4.lib referencing lz4.dll, but only liblz4.dll is packaged.
+:: If liblz4.lib exists (references liblz4.dll), patch liblz4.pc so meson
+:: links against liblz4.lib and the binary loads liblz4.dll at runtime.
+if exist %LIBRARY_LIB%\liblz4.lib (
+    powershell -Command "(gc '%LIBRARY_LIB%\pkgconfig\liblz4.pc') -replace '-llz4\b', '-lliblz4' | sc '%LIBRARY_LIB%\pkgconfig\liblz4.pc'"
+    if errorlevel 1 exit 1
+)
+
 meson setup ^
    --prefix=%LIBRARY_PREFIX% ^
    --backend ninja ^
@@ -41,8 +49,10 @@ meson setup ^
    -Dnls=disabled ^
    -Dplperl=disabled ^
    -Dpltcl=disabled ^
+   -Dlz4=enabled ^
    -Dextra_include_dirs=%LIBRARY_INC% ^
    -Dextra_lib_dirs=%LIBRARY_LIB% ^
+   -Dpkg_config_path=%LIBRARY_LIB%\pkgconfig ^
    build
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -33,14 +33,6 @@ if "%ARCH%" == "32" (
    set ARCH=x64
 )
 
-:: lz4-c ships lz4.lib referencing lz4.dll, but only liblz4.dll is packaged.
-:: If liblz4.lib exists (references liblz4.dll), patch liblz4.pc so meson
-:: links against liblz4.lib and the binary loads liblz4.dll at runtime.
-if exist %LIBRARY_LIB%\liblz4.lib (
-    powershell -Command "(gc '%LIBRARY_LIB%\pkgconfig\liblz4.pc') -replace '-llz4\b', '-lliblz4' | sc '%LIBRARY_LIB%\pkgconfig\liblz4.pc'"
-    if errorlevel 1 exit 1
-)
-
 meson setup ^
    --prefix=%LIBRARY_PREFIX% ^
    --backend ninja ^
@@ -49,10 +41,8 @@ meson setup ^
    -Dnls=disabled ^
    -Dplperl=disabled ^
    -Dpltcl=disabled ^
-   -Dlz4=enabled ^
    -Dextra_include_dirs=%LIBRARY_INC% ^
    -Dextra_lib_dirs=%LIBRARY_LIB% ^
-   -Dpkg_config_path=%LIBRARY_LIB%\pkgconfig ^
    build
 if errorlevel 1 exit 1
 

--- a/recipe/install_db.bat
+++ b/recipe/install_db.bat
@@ -1,3 +1,1 @@
 meson install --no-rebuild -C build
-:: lz4-c conda package ships liblz4.dll but postgres links against lz4.dll
-if not exist %LIBRARY_BIN%\lz4.dll copy %LIBRARY_BIN%\liblz4.dll %LIBRARY_BIN%\lz4.dll

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
## Links
- https://anaconda.atlassian.net/browse/PKG-16106

## Changes
- `bld.bat`: if `liblz4.lib` exists, patch `liblz4.pc` in-place before `meson setup` to replace `-llz4` with `-lliblz4`, so meson links against `liblz4.lib` (which references `liblz4.dll`) instead of `lz4.lib` (which references the non-existent `lz4.dll`); also add `-Dlz4=enabled` and `-Dpkg_config_path` to the meson setup call
- `install_db.bat`: remove the `liblz4.dll → lz4.dll` copy that was vendoring a second copy of lz4 into the package

## Notes
- `lz4-c` ships `liblz4.dll` but `lz4.lib` has `lz4.dll` baked in as the runtime DLL name — the old fix copied the DLL to paper over this, embedding it in the package; the new fix patches the pkg-config so the linker records `liblz4.dll` directly
- The `if exist liblz4.lib` guard is defensive in case the lz4-c package layout changes