### PR TITLE
Dont copy lz4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-# the conda-build parameters to use
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -40,6 +40,7 @@ meson setup ^
    -Dcassert=false ^
    -Dnls=disabled ^
    -Dplperl=disabled ^
+   -Dplpython=disabled ^
    -Dpltcl=disabled ^
    -Dextra_include_dirs=%LIBRARY_INC% ^
    -Dextra_lib_dirs=%LIBRARY_LIB% ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-
-# rebuild for icu 78.3
-icu:
-  - 78.3
-libxml2:
-  - 2.14.4

--- a/recipe/install_db.bat
+++ b/recipe/install_db.bat
@@ -1,3 +1,1 @@
 meson install --no-rebuild -C build
-:: lz4-c conda package ships liblz4.dll but postgres links against lz4.dll
-if not exist %LIBRARY_BIN%\lz4.dll copy %LIBRARY_BIN%\liblz4.dll %LIBRARY_BIN%\lz4.dll

--- a/recipe/install_runtime.bat
+++ b/recipe/install_runtime.bat
@@ -6,3 +6,7 @@ MOVE %LIBRARY_BIN%\pg_config.exe backup
 RD /s /q %LIBRARY_BIN%
 mkdir %LIBRARY_BIN%
 MOVE backup\* %LIBRARY_BIN%
+
+REM Meson installs server/contrib modules into Library\lib.  Those modules
+REM belong to the postgresql output, not libpq, and pull in server-only DSOs.
+IF EXIST "%LIBRARY_LIB%\*.dll" DEL /Q "%LIBRARY_LIB%\*.dll"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -124,6 +124,7 @@ outputs:
         - openldap {{ openldap }}  # [not win]
         - openssl {{ openssl }}
         - zlib {{ zlib }}          # [win]
+        - libxml2 {{ libxml2 }}    # [win]
         - msinttypes r26           # [win and vc<14]
       run:
         # Versions constraints come from run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -124,7 +124,6 @@ outputs:
         - openldap {{ openldap }}  # [not win]
         - openssl {{ openssl }}
         - zlib {{ zlib }}          # [win]
-        - libxml2 {{ libxml2 }}    # [win]
         - msinttypes r26           # [win and vc<14]
       run:
         # Versions constraints come from run_exports
@@ -143,6 +142,7 @@ outputs:
         - test -f $PREFIX/lib/libpq.dylib                  # [osx]
         - IF NOT EXIST %LIBRARY_BIN%\libpq.dll EXIT 1      # [win]
         - IF NOT EXIST %LIBRARY_BIN%\pg_config.exe EXIT 1  # [win]
+        - IF EXIST %LIBRARY_LIB%\*.dll EXIT 1              # [win]
     about:
       summary: The postgres runtime libraries and utilities (not the server itself)
 


### PR DESCRIPTION
postgresql rebuild

**Destination channel:** defaults

### Links

### Explanation of changes:

- Re-enable overlinking checks by deleting abs.yaml
- Fix overlinking to `ERROR (libpq,Library/lib/jsonb_plpython3.dll):` by setting `-Dplpython=disabled`  jsonb_plpython3.dll is a PostgreSQL server extension, not part of libpq. 
- Remove postgres server components from libpq, fixes `  ERROR (libpq,Library/lib/pgxml.dll): $RPATH/libxml2.dll not found in packages`
- Remove lz4 copy hack that was fixed in https://github.com/AnacondaRecipes/lz4-c-feedstock/pull/9

