### PR TITLE
postgresql 18.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "17.10" %}
+{% set version = "18.4" %}
 {% set libpqver = '.'.join(("5", version.split('.')[0])) %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://ftp.postgresql.org/pub/source/v{{ version }}/postgresql-{{ version }}.tar.bz2
-  sha256: 078a03516dcdbdb705fecaf415ea3d13a956c589e46f09fed68a06fb00598c90
+  sha256: 81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094
   patches:
     - patches/fix_gssapi_setenv_win.patch       # [win]
     - patches/fix_auth_setenv_win.patch         # [win]
@@ -16,7 +16,7 @@ source:
     - patches/fix_mac10_9_clock_realtime.patch  # [osx]
 
 build:
-  number: 2
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
## Links

- Jira: https://anaconda.atlassian.net/browse/PKG-15952
- Homepage: https://www.postgresql.org
- conda-forge recipe: https://github.com/conda-forge/postgresql-feedstock
- Source: https://git.postgresql.org/gitweb/?p=postgresql.git;a=summary

## Changes

- Bump `postgresql`/`libpq` from `17.10` to `18.4` (Stage 001 of the postgresql/libpq 18 migration, PKG-15951)
- Reset build number to 0
- Update sha256 for the 18.4 source tarball

## Notes

- Ticket specified target "18" without a patch level; 18.0-18.3 carry several high-severity CVEs (up to CVSS 8.8, including arbitrary code execution via pgcrypto/intarray/multibyte handling) that are fixed in 18.4, so targeted 18.4 directly: https://www.postgresql.org/support/security/
- All 5 existing patches were verified to apply cleanly to the 18.4 source with no fuzz/offset.
- PG18 adds a new io_uring-based AIO backend (`--with-liburing`); skipped for now since `liburing` isn't yet packaged in the `main` channel. AIO itself still works via the default `worker` io_method without it.